### PR TITLE
Include requirements and tests in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,9 @@
-# Include the README
-include *.md
-
-# Include the license file
-include LICENSE.txt
+# Include the README, requirements, license, etc.
+include *.md *.txt
 
 # Include the data files
-recursive-include resources *
+recursive-include audio_degrader *
+
+# Include tests
+graft tests
+include Makefile


### PR DESCRIPTION
This makes it easier for downstream packagers.  Also simplify the `Manifest.in` file somewhat.