### PR TITLE
remove librosa.output usage: use soundfile directly

### DIFF
--- a/audio_degrader/AudioFile.py
+++ b/audio_degrader/AudioFile.py
@@ -1,7 +1,10 @@
-import os
-import librosa as lr
 import logging
+import os
 import uuid
+
+import librosa as lr
+import soundfile as sf
+
 from utils import run
 
 
@@ -38,8 +41,10 @@ class AudioFile(object):
 
     def _update_mirror_file(self):
         logging.debug("Updating mirror file")
-        lr.output.write_wav(self.tmp_path, self.samples,
-                            self.sample_rate, norm=False)
+        wav = self.samples
+        if wav.ndim > 1 and wav.shape[0] == 2:
+            wav = wav.T
+        sf.write(self.tmp_path, wav,  self.sample_rate)
 
     def to_wav(self, output_path):
         out, err, returncode = run(

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     url='https://github.com/EliosMolina/audio_degrader',
     download_url='https://github.com/EliosMolina/audio_degrader/archive/master.zip',
     keywords=['audio', 'degradation', 'augmentation'],
-    install_requires=['librosa >= 0.6.0'],
+    install_requires=['librosa >= 0.6.0', 'soundfile'],
     package_data={'audio_degrader': ['resources/impulse_responses/*',
                                      'resources/sounds/*']},
     scripts=['scripts/audio_degrader'],


### PR DESCRIPTION
librosa removed the output module (https://github.com/librosa/librosa/pull/1062) use soundfile directly.